### PR TITLE
Use $PWD instead of . in Docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Note that the version of skorch must be 0.8 to ensure that the pretrained models
 2. Build your image using `Dockerfile` or pull `docker pull yanndubs/npf:gpu`
 
 3. Create and run a container, e.g.:
-`docker run --gpus all --init -d --ipc=host --name npf -v .:/Neural-Process-Family -p 8888:8888 -p 6006:6006 yanndubs/npf:gpu jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --allow-root`
+`docker run --gpus all --init -d --ipc=host --name npf -v $PWD:/Neural-Process-Family -p 8888:8888 -p 6006:6006 yanndubs/npf:gpu jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --allow-root`
 
 ## Examples
 


### PR DESCRIPTION
When trying to run the provided Docker commands, `.` raises errors, and replacing with $PWD is an equivalent fix and should work on most Linux distributions. It also seems like `-d` may not be the most appropriate option to have if running locally, since you may want to use the links that jupyter outputs, which `-d` supresses