### PR TITLE
Added an upper limit on matplotlib version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 skorch==0.8 # use the correct skorch version if you want to use the pretrained models
 torch
 torchvision
-matplotlib
+matplotlib<=3.7.5 # reqd as of 12 June 2024 - see https://github.com/YannDubs/Neural-Process-Family/issues/13
 tqdm
 scikit-learn
 joblib


### PR DESCRIPTION
See https://github.com/YannDubs/Neural-Process-Family/issues/13.
> * matplotlib version has to be <3.8 otherwise you get the error `ImportError: cannot import name 'MatplotlibDeprecationWarning' from 'matplotlib.cbook'` in utils/visualize/helpers.py
