### PR TITLE
Weight Initialization Bug

### DIFF
--- a/npf/utils/initialization.py
+++ b/npf/utils/initialization.py
@@ -45,7 +45,7 @@ def get_activation_name(activation):
     }
     for k, v in mapper.items():
         if isinstance(activation, k):
-            return k
+            return v
 
     raise ValueError("Unkown given activation type : {}".format(activation))
 


### PR DESCRIPTION
`get_activation_name` appears to be expected to return a string using the `mapper`, but I think it was erroneously returning the key (a class, not a string). This leads to a [null operation in `linear_init` since](https://github.com/YannDubs/Neural-Process-Family/blob/master/npf/utils/initialization.py#L92) all the `if/elif` statements won't match.

I suppose the result would have been some weights (in the MLP class for example) which weren't being initialized as intended. I can't imagine the consequences of such a bug would be large, but perhaps worth the fix?